### PR TITLE
Added support for ARM64

### DIFF
--- a/compile-list.txt
+++ b/compile-list.txt
@@ -1,6 +1,8 @@
 win-x64
 win-x86
 win-arm
+win-arm64
 linux-x64
 linux-arm
+linux-arm64
 osx-x64


### PR DESCRIPTION
I've noticed that the build list does not include ARM64 versions for Windows and Linux, which are crucial for servers, as the ARM32 versions don't work on ARM64 .NET